### PR TITLE
feat(ai): multi-provider streaming, Postgres init, conversation fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,6 +154,13 @@ ARLOG_TIMEOUT=3600
 # Google Gemini API key (primary AI service)
 GOOGLE_API_KEY=your_google_api_key_here
 
+# OpenAI-compatible APIs (optional server defaults; users can also BYOK from the AI page)
+OPENAI_API_KEY=
+OPENAI_BASE_URL=https://api.openai.com/v1
+
+# Local Ollama OpenAI-compatible base (optional server default)
+OLLAMA_BASE_URL=http://127.0.0.1:11434/v1
+
 # Anthropic API key (optional, legacy skills)
 ANTHROPIC_API_KEY=
 

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,9 @@ docker-build: ## Build Docker images for API and Frontend
 
 migrate-up: ## Run PostgreSQL migrations (up)
 	@echo "$(GREEN)Running PostgreSQL migrations...$(RESET)"
-	docker compose exec -T postgres psql -U remedyiq -d remedyiq < backend/migrations/001_initial.up.sql
+	docker compose exec -T postgres psql -U remedyiq -d remedyiq -v ON_ERROR_STOP=1 < backend/migrations/001_initial.up.sql
+	docker compose exec -T postgres psql -U remedyiq -d remedyiq -v ON_ERROR_STOP=1 < backend/migrations/002_search_features.up.sql
+	docker compose exec -T postgres psql -U remedyiq -d remedyiq -v ON_ERROR_STOP=1 < backend/migrations/003_conversations.up.sql
 
 migrate-down: ## Rollback PostgreSQL migrations (down)
 	@echo "$(YELLOW)Rolling back PostgreSQL migrations...$(RESET)"

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -127,7 +127,19 @@ func main() {
 		slog.Warn("Gemini client initialization failed; AI streaming will not work", "error", err)
 	}
 
-	aiStreamHandler := handlers.NewAIStreamHandler(geminiClient, aiRegistry, aiRouter, pg, ch, redis)
+	aiStreamHandler := handlers.NewAIStreamHandler(
+		geminiClient,
+		aiRegistry,
+		aiRouter,
+		pg,
+		ch,
+		redis,
+		ai.ServerLLMDefaults{
+			OpenAIAPIKey:  cfg.OpenAIAPIKey,
+			OpenAIBaseURL: cfg.OpenAIBaseURL,
+			OllamaBaseURL: cfg.OllamaBaseURL,
+		},
+	)
 	conversationsHandler := handlers.NewConversationsHandler(pg)
 	conversationDetailHandler := handlers.NewConversationDetailHandler(pg)
 

--- a/backend/internal/ai/gemini_client.go
+++ b/backend/internal/ai/gemini_client.go
@@ -56,24 +56,62 @@ type StreamChunk struct {
 }
 
 func (c *GeminiClient) StreamQuery(ctx context.Context, systemPrompt string, messages []Message, maxTokens int) <-chan StreamChunk {
+	return c.StreamQueryWithOverrides(ctx, "", "", systemPrompt, messages, maxTokens)
+}
+
+// StreamQueryWithOverrides streams from Gemini using the configured client by default.
+// If apiKeyOverride is non-empty, a short-lived client is created for that key (BYOK).
+// If modelOverride is non-empty, it is used as the model name for this request.
+func (c *GeminiClient) StreamQueryWithOverrides(ctx context.Context, apiKeyOverride, modelOverride string, systemPrompt string, messages []Message, maxTokens int) <-chan StreamChunk {
 	ch := make(chan StreamChunk, 64)
 
 	go func() {
 		defer close(ch)
 
-		if !c.enabled || c.client == nil {
+		if maxTokens <= 0 {
+			maxTokens = 4096
+		}
+
+		client := c.client
+		model := c.model
+		logger := c.logger
+		enabled := c.enabled && c.client != nil
+
+		if strings.TrimSpace(apiKeyOverride) != "" {
+			modelName := strings.TrimSpace(modelOverride)
+			if modelName == "" {
+				modelName = "gemini-2.5-flash"
+			}
+			tmpCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			tmpClient, err := genai.NewClient(tmpCtx, &genai.ClientConfig{
+				APIKey:  strings.TrimSpace(apiKeyOverride),
+				Backend: genai.BackendGeminiAPI,
+			})
+			cancel()
+			if err != nil {
+				c.logger.Error("gemini byok client init failed", "error", err)
+				ch <- StreamChunk{Error: fmt.Errorf("gemini client init: %w", err)}
+				return
+			}
+			client = tmpClient
+			model = modelName
+			logger = c.logger.With("byok", true)
+			enabled = client != nil
+		} else {
+			if strings.TrimSpace(modelOverride) != "" {
+				model = strings.TrimSpace(modelOverride)
+			}
+		}
+
+		if !enabled || client == nil {
 			ch <- StreamChunk{
-				Text:    "AI streaming is not configured. Please set GOOGLE_API_KEY.",
+				Text:    "AI streaming is not configured. Please set GOOGLE_API_KEY or provide a Gemini API key in AI settings.",
 				IsFinal: true,
 			}
 			return
 		}
 
-		if maxTokens <= 0 {
-			maxTokens = 4096
-		}
-
-		contents := c.buildContents(messages)
+		contents := buildGeminiContents(messages)
 		config := &genai.GenerateContentConfig{
 			SystemInstruction: &genai.Content{
 				Parts: []*genai.Part{{Text: systemPrompt}},
@@ -85,14 +123,14 @@ func (c *GeminiClient) StreamQuery(ctx context.Context, systemPrompt string, mes
 		var finalResp *genai.GenerateContentResponse
 		start := time.Now()
 
-		for resp, err := range c.client.Models.GenerateContentStream(
+		for resp, err := range client.Models.GenerateContentStream(
 			ctx,
-			c.model,
+			model,
 			contents,
 			config,
 		) {
 			if err != nil {
-				c.logger.Error("stream error", "error", err)
+				logger.Error("stream error", "error", err)
 				ch <- StreamChunk{Error: fmt.Errorf("stream error: %w", err)}
 				return
 			}
@@ -115,7 +153,7 @@ func (c *GeminiClient) StreamQuery(ctx context.Context, systemPrompt string, mes
 			tokensOut = int(finalResp.UsageMetadata.CandidatesTokenCount)
 		}
 
-		c.logger.Info("stream completed",
+		logger.Info("stream completed",
 			"latency_ms", time.Since(start).Milliseconds(),
 			"tokens_in", tokensIn,
 			"tokens_out", tokensOut,
@@ -132,7 +170,7 @@ func (c *GeminiClient) StreamQuery(ctx context.Context, systemPrompt string, mes
 	return ch
 }
 
-func (c *GeminiClient) buildContents(messages []Message) []*genai.Content {
+func buildGeminiContents(messages []Message) []*genai.Content {
 	contents := make([]*genai.Content, 0, len(messages))
 	for _, msg := range messages {
 		role := "user"
@@ -159,7 +197,18 @@ type StreamRequest struct {
 	JobID          string     `json:"job_id"`
 	ConversationID *uuid.UUID `json:"conversation_id,omitempty"`
 	SkillName      string     `json:"skill_name,omitempty"`
-	AutoRoute      bool       `json:"auto_route"`
+	// Skill is a legacy/frontend alias for SkillName.
+	Skill     string `json:"skill,omitempty"`
+	AutoRoute bool   `json:"auto_route"`
+
+	// Provider selects the LLM backend: gemini (default), openai, ollama.
+	Provider string `json:"provider,omitempty"`
+	// ApiKey optional BYOK value (never logged).
+	ApiKey string `json:"api_key,omitempty"`
+	// OpenAIBaseURL optional override for OpenAI-compatible servers (e.g. Ollama http://127.0.0.1:11434/v1).
+	OpenAIBaseURL string `json:"openai_base_url,omitempty"`
+	// Model optional per-request model id (e.g. gpt-4o-mini, llama3.2, gemini-2.5-flash).
+	Model string `json:"model,omitempty"`
 }
 
 type SSEEvent struct {

--- a/backend/internal/ai/openai_base_url.go
+++ b/backend/internal/ai/openai_base_url.go
@@ -1,0 +1,49 @@
+package ai
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const maxOpenAICompatibleBaseURLLen = 512
+
+// ValidateOpenAICompatibleBaseURL rejects obviously unsafe hosts used in SSRF
+// attacks while allowing typical LAN / localhost Ollama installs.
+func ValidateOpenAICompatibleBaseURL(raw string) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return fmt.Errorf("base url is required")
+	}
+	if len(raw) > maxOpenAICompatibleBaseURLLen {
+		return fmt.Errorf("base url is too long")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid base url: %w", err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+	default:
+		return fmt.Errorf("base url scheme must be http or https")
+	}
+	host := strings.ToLower(strings.TrimSpace(u.Hostname()))
+	if host == "" {
+		return fmt.Errorf("base url must include a host")
+	}
+	if host == "169.254.169.254" || strings.HasPrefix(host, "169.254.") {
+		return fmt.Errorf("link-local metadata hosts are not allowed")
+	}
+	if host == "metadata.google.internal" {
+		return fmt.Errorf("host is not allowed")
+	}
+	return nil
+}
+
+// NormalizeOpenAICompatibleBaseURL trims trailing slashes so callers can append "/chat/completions".
+func NormalizeOpenAICompatibleBaseURL(raw string) (string, error) {
+	if err := ValidateOpenAICompatibleBaseURL(raw); err != nil {
+		return "", err
+	}
+	return strings.TrimRight(strings.TrimSpace(raw), "/"), nil
+}

--- a/backend/internal/ai/openai_base_url_test.go
+++ b/backend/internal/ai/openai_base_url_test.go
@@ -1,0 +1,19 @@
+package ai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateOpenAICompatibleBaseURL(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ValidateOpenAICompatibleBaseURL("http://127.0.0.1:11434/v1"))
+	require.NoError(t, ValidateOpenAICompatibleBaseURL("https://api.openai.com/v1"))
+
+	require.Error(t, ValidateOpenAICompatibleBaseURL(""))
+	require.Error(t, ValidateOpenAICompatibleBaseURL("http://169.254.169.254/latest/meta-data"))
+	require.Error(t, ValidateOpenAICompatibleBaseURL("https://metadata.google.internal/"))
+	require.Error(t, ValidateOpenAICompatibleBaseURL("ftp://example.com/v1"))
+}

--- a/backend/internal/ai/openai_compat_stream.go
+++ b/backend/internal/ai/openai_compat_stream.go
@@ -1,0 +1,172 @@
+package ai
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// StreamOpenAICompatible streams chat completions from any OpenAI-compatible HTTP API
+// (OpenAI, Ollama /v1, vLLM, LiteLLM, etc.) using the documented SSE chunk format.
+func StreamOpenAICompatible(ctx context.Context, baseURL, apiKey, model, systemPrompt string, messages []Message) <-chan StreamChunk {
+	ch := make(chan StreamChunk, 64)
+	logger := slog.Default().With("component", "openai_compat")
+
+	go func() {
+		defer close(ch)
+
+		base, err := NormalizeOpenAICompatibleBaseURL(baseURL)
+		if err != nil {
+			ch <- StreamChunk{Error: err}
+			return
+		}
+		if model == "" {
+			ch <- StreamChunk{Error: fmt.Errorf("model is required for OpenAI-compatible providers")}
+			return
+		}
+
+		payload := map[string]any{
+			"model":    model,
+			"stream":   true,
+			"messages": buildOpenAIChatMessages(systemPrompt, messages),
+		}
+
+		body, err := json.Marshal(payload)
+		if err != nil {
+			ch <- StreamChunk{Error: fmt.Errorf("marshal request: %w", err)}
+			return
+		}
+
+		endpoint := base + "/chat/completions"
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+		if err != nil {
+			ch <- StreamChunk{Error: fmt.Errorf("build request: %w", err)}
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "text/event-stream")
+		if strings.TrimSpace(apiKey) != "" {
+			req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(apiKey))
+		}
+
+		client := &http.Client{Timeout: 0}
+		start := time.Now()
+		resp, err := client.Do(req)
+		if err != nil {
+			ch <- StreamChunk{Error: fmt.Errorf("request failed: %w", err)}
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+			ch <- StreamChunk{Error: fmt.Errorf("upstream returned %s: %s", resp.Status, strings.TrimSpace(string(b)))}
+			return
+		}
+
+		scanner := bufio.NewScanner(resp.Body)
+		// OpenAI streams can emit large JSON lines.
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+		var promptTokens, completionTokens int
+
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			if !strings.HasPrefix(line, "data:") {
+				continue
+			}
+			data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if data == "" || data == "[DONE]" {
+				if data == "[DONE]" {
+					break
+				}
+				continue
+			}
+
+			var chunk openAIChatCompletionChunk
+			if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+				logger.Debug("skip malformed sse chunk", "error", err)
+				continue
+			}
+			if chunk.Usage != nil {
+				promptTokens = chunk.Usage.PromptTokens
+				completionTokens = chunk.Usage.CompletionTokens
+			}
+			if len(chunk.Choices) == 0 {
+				continue
+			}
+			delta := chunk.Choices[0].Delta.Content
+			if delta != "" {
+				ch <- StreamChunk{Text: delta}
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			ch <- StreamChunk{Error: fmt.Errorf("read stream: %w", err)}
+			return
+		}
+
+		logger.Info("openai-compatible stream completed",
+			"latency_ms", time.Since(start).Milliseconds(),
+			"prompt_tokens", promptTokens,
+			"completion_tokens", completionTokens,
+		)
+
+		ch <- StreamChunk{
+			IsFinal:   true,
+			TokensIn:  promptTokens,
+			TokensOut: completionTokens,
+		}
+	}()
+
+	return ch
+}
+
+type openAIChatCompletionChunk struct {
+	Choices []struct {
+		Delta struct {
+			Content string `json:"content"`
+		} `json:"delta"`
+	} `json:"choices"`
+	Usage *struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+	} `json:"usage"`
+}
+
+func buildOpenAIChatMessages(systemPrompt string, messages []Message) []map[string]string {
+	out := make([]map[string]string, 0, len(messages)+1)
+	if strings.TrimSpace(systemPrompt) != "" {
+		out = append(out, map[string]string{
+			"role":    "system",
+			"content": systemPrompt,
+		})
+	}
+	for _, m := range messages {
+		content := strings.TrimSpace(m.Content)
+		if content == "" {
+			continue
+		}
+		role := strings.ToLower(strings.TrimSpace(m.Role))
+		if role == "model" {
+			role = "assistant"
+		}
+		if role != "user" && role != "assistant" && role != "system" {
+			role = "user"
+		}
+		out = append(out, map[string]string{
+			"role":    role,
+			"content": content,
+		})
+	}
+	return out
+}

--- a/backend/internal/ai/openai_compat_stream_test.go
+++ b/backend/internal/ai/openai_compat_stream_test.go
@@ -1,0 +1,50 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamOpenAICompatible_MockServer(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method", http.StatusMethodNotAllowed)
+			return
+		}
+		fl, ok := w.(http.Flusher)
+		require.True(t, ok)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprintf(w, "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n")
+		fl.Flush()
+		_, _ = fmt.Fprintf(w, "data: [DONE]\n\n")
+		fl.Flush()
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	base := srv.URL
+	ch := StreamOpenAICompatible(ctx, base, "", "test-model", "sys", []Message{{Role: "user", Content: "yo"}})
+
+	var got string
+	for chunk := range ch {
+		if chunk.Error != nil {
+			t.Fatalf("unexpected error: %v", chunk.Error)
+		}
+		got += chunk.Text
+	}
+
+	require.Equal(t, "Hi", got)
+}

--- a/backend/internal/ai/server_llm_defaults.go
+++ b/backend/internal/ai/server_llm_defaults.go
@@ -1,0 +1,9 @@
+package ai
+
+// ServerLLMDefaults holds optional server-side credentials for OpenAI-compatible APIs.
+// User-supplied keys in StreamRequest still override these defaults when present.
+type ServerLLMDefaults struct {
+	OpenAIAPIKey  string
+	OpenAIBaseURL string
+	OllamaBaseURL string
+}

--- a/backend/internal/api/handlers/ai_stream.go
+++ b/backend/internal/api/handlers/ai_stream.go
@@ -28,9 +28,11 @@ type AIStreamHandler struct {
 	ch       storage.ClickHouseStore
 	redis    storage.RedisCache
 	logger   *slog.Logger
+
+	defaults ai.ServerLLMDefaults
 }
 
-func NewAIStreamHandler(gemini *ai.GeminiClient, registry *ai.Registry, router *ai.Router, db *storage.PostgresClient, ch storage.ClickHouseStore, redis storage.RedisCache) *AIStreamHandler {
+func NewAIStreamHandler(gemini *ai.GeminiClient, registry *ai.Registry, router *ai.Router, db *storage.PostgresClient, ch storage.ClickHouseStore, redis storage.RedisCache, defaults ai.ServerLLMDefaults) *AIStreamHandler {
 	return &AIStreamHandler{
 		gemini:   gemini,
 		registry: registry,
@@ -38,6 +40,7 @@ func NewAIStreamHandler(gemini *ai.GeminiClient, registry *ai.Registry, router *
 		db:       db,
 		ch:       ch,
 		redis:    redis,
+		defaults: defaults,
 		logger:   slog.Default().With("handler", "ai_stream"),
 	}
 }
@@ -96,6 +99,9 @@ func (h *AIStreamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	skillName := req.SkillName
+	if skillName == "" && strings.TrimSpace(req.Skill) != "" {
+		skillName = strings.TrimSpace(req.Skill)
+	}
 	if skillName == "" && req.AutoRoute {
 		skillName = h.router.Route(req.Query)
 	} else if skillName == "" {
@@ -177,7 +183,7 @@ func (h *AIStreamHandler) streamSSE(ctx context.Context, w http.ResponseWriter, 
 	systemPrompt := h.buildSystemPrompt(skillName, logContext)
 	messages := h.buildConversationMessages(ctx, conversation)
 
-	stream := h.gemini.StreamQuery(ctx, systemPrompt, messages, 4096)
+	stream := h.openLLMStream(ctx, req, systemPrompt, messages)
 
 	var fullContent strings.Builder
 	var tokensIn, tokensOut int
@@ -227,6 +233,63 @@ func (h *AIStreamHandler) streamSSE(ctx context.Context, w http.ResponseWriter, 
 	h.writeSSE(w, flusher, "done", ai.SSEDoneData{
 		FollowUps: assistantMsg.FollowUps,
 	})
+}
+
+func normalizeStreamProvider(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "google", "gemini":
+		return "gemini"
+	case "openai", "chatgpt":
+		return "openai"
+	case "ollama", "local":
+		return "ollama"
+	default:
+		return strings.ToLower(strings.TrimSpace(raw))
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func (h *AIStreamHandler) openLLMStream(ctx context.Context, req *ai.StreamRequest, systemPrompt string, messages []ai.Message) <-chan ai.StreamChunk {
+	switch normalizeStreamProvider(req.Provider) {
+	case "openai":
+		base := firstNonEmpty(req.OpenAIBaseURL, h.defaults.OpenAIBaseURL)
+		apiKey := firstNonEmpty(req.ApiKey, h.defaults.OpenAIAPIKey)
+		model := firstNonEmpty(req.Model, "gpt-4o-mini")
+		normalized, err := ai.NormalizeOpenAICompatibleBaseURL(base)
+		if err != nil {
+			return singleStreamError(err)
+		}
+		return ai.StreamOpenAICompatible(ctx, normalized, apiKey, model, systemPrompt, messages)
+	case "ollama":
+		base := firstNonEmpty(req.OpenAIBaseURL, h.defaults.OllamaBaseURL)
+		apiKey := strings.TrimSpace(req.ApiKey)
+		model := firstNonEmpty(req.Model, "llama3.2")
+		normalized, err := ai.NormalizeOpenAICompatibleBaseURL(base)
+		if err != nil {
+			return singleStreamError(err)
+		}
+		return ai.StreamOpenAICompatible(ctx, normalized, apiKey, model, systemPrompt, messages)
+	default:
+		if h.gemini == nil {
+			return singleStreamError(fmt.Errorf("gemini client is not configured"))
+		}
+		return h.gemini.StreamQueryWithOverrides(ctx, strings.TrimSpace(req.ApiKey), strings.TrimSpace(req.Model), systemPrompt, messages, 4096)
+	}
+}
+
+func singleStreamError(err error) <-chan ai.StreamChunk {
+	ch := make(chan ai.StreamChunk, 1)
+	ch <- ai.StreamChunk{Error: err}
+	close(ch)
+	return ch
 }
 
 func (h *AIStreamHandler) buildSystemPrompt(skillName, logContext string) string {

--- a/backend/internal/api/handlers/ai_stream_test.go
+++ b/backend/internal/api/handlers/ai_stream_test.go
@@ -20,7 +20,7 @@ import (
 func TestAIStreamHandler_MissingTenantContext(t *testing.T) {
 	registry := ai.NewRegistry()
 	router := ai.NewRouter()
-	h := NewAIStreamHandler(nil, registry, router, nil, nil, nil)
+	h := NewAIStreamHandler(nil, registry, router, nil, nil, nil, ai.ServerLLMDefaults{})
 
 	body := `{"query":"test"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/ai/stream", bytes.NewBufferString(body))
@@ -34,7 +34,7 @@ func TestAIStreamHandler_MissingTenantContext(t *testing.T) {
 func TestAIStreamHandler_MissingUserContext(t *testing.T) {
 	registry := ai.NewRegistry()
 	router := ai.NewRouter()
-	h := NewAIStreamHandler(nil, registry, router, nil, nil, nil)
+	h := NewAIStreamHandler(nil, registry, router, nil, nil, nil, ai.ServerLLMDefaults{})
 
 	body := `{"query":"test","job_id":"` + uuid.New().String() + `"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/ai/stream", bytes.NewBufferString(body))
@@ -50,7 +50,7 @@ func TestAIStreamHandler_MissingUserContext(t *testing.T) {
 func TestAIStreamHandler_MissingJobID(t *testing.T) {
 	registry := ai.NewRegistry()
 	router := ai.NewRouter()
-	h := NewAIStreamHandler(nil, registry, router, nil, nil, nil)
+	h := NewAIStreamHandler(nil, registry, router, nil, nil, nil, ai.ServerLLMDefaults{})
 
 	body := `{"query":"test"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/ai/stream", bytes.NewBufferString(body))
@@ -68,7 +68,7 @@ func TestAIStreamHandler_MissingJobID(t *testing.T) {
 func TestAIStreamHandler_MissingQuery(t *testing.T) {
 	registry := ai.NewRegistry()
 	router := ai.NewRouter()
-	h := NewAIStreamHandler(nil, registry, router, nil, nil, nil)
+	h := NewAIStreamHandler(nil, registry, router, nil, nil, nil, ai.ServerLLMDefaults{})
 
 	body := `{}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/ai/stream", bytes.NewBufferString(body))
@@ -86,7 +86,7 @@ func TestAIStreamHandler_MissingQuery(t *testing.T) {
 func TestAIStreamHandler_QueryTooLong(t *testing.T) {
 	registry := ai.NewRegistry()
 	router := ai.NewRouter()
-	h := NewAIStreamHandler(nil, registry, router, nil, nil, nil)
+	h := NewAIStreamHandler(nil, registry, router, nil, nil, nil, ai.ServerLLMDefaults{})
 
 	longQuery := strings.Repeat("a", 2001)
 	body := `{"query":"` + longQuery + `"}`
@@ -137,7 +137,7 @@ func TestAIStreamHandler_SSETokenEventFormat(t *testing.T) {
 func TestAIStreamHandler_BuildSystemPrompt_UsesSummaryContext(t *testing.T) {
 	registry := ai.NewRegistry()
 	router := ai.NewRouter()
-	h := NewAIStreamHandler(nil, registry, router, nil, nil, nil)
+	h := NewAIStreamHandler(nil, registry, router, nil, nil, nil, ai.ServerLLMDefaults{})
 
 	prompt := h.buildSystemPrompt("nl_query", "## Log Analysis Summary")
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -48,6 +48,13 @@ type Config struct {
 	GoogleAPIKey string
 	GoogleModel  string
 
+	// OpenAI-compatible APIs (OpenAI, LiteLLM, etc.)
+	OpenAIAPIKey  string
+	OpenAIBaseURL string
+
+	// Ollama local LLM (OpenAI-compatible /v1 base URL)
+	OllamaBaseURL string
+
 	// App
 	Environment string // development, staging, production
 	LogLevel    string
@@ -81,6 +88,9 @@ func Load() (*Config, error) {
 		AnthropicAPIKey:          getEnv("ANTHROPIC_API_KEY", ""),
 		GoogleAPIKey:             getEnv("GOOGLE_API_KEY", ""),
 		GoogleModel:              getEnv("GOOGLE_MODEL", "gemini-2.5-flash"),
+		OpenAIAPIKey:             getEnv("OPENAI_API_KEY", ""),
+		OpenAIBaseURL:            strings.TrimRight(strings.TrimSpace(getEnv("OPENAI_BASE_URL", "https://api.openai.com/v1")), "/"),
+		OllamaBaseURL:            strings.TrimRight(strings.TrimSpace(getEnv("OLLAMA_BASE_URL", "http://127.0.0.1:11434/v1")), "/"),
 		Environment:              getEnv("ENVIRONMENT", "development"),
 		LogLevel:                 getEnv("LOG_LEVEL", "info"),
 		BlevePath:                getEnv("BLEVE_PATH", "./data/bleve"),

--- a/backend/migrations/003_conversations.up.sql
+++ b/backend/migrations/003_conversations.up.sql
@@ -88,6 +88,7 @@ ELSIF TG_OP = 'DELETE' THEN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS trg_message_counter ON messages;
 CREATE TRIGGER trg_message_counter
     AFTER INSERT OR DELETE ON messages
     FOR EACH ROW

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,10 @@ services:
       POSTGRES_PASSWORD: remedyiq
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      # Init runs *.sql in this directory once (lexicographic order) on first empty data dir.
       - ./backend/migrations/001_initial.up.sql:/docker-entrypoint-initdb.d/001_initial.sql:ro
+      - ./backend/migrations/002_search_features.up.sql:/docker-entrypoint-initdb.d/002_search_features.sql:ro
+      - ./backend/migrations/003_conversations.up.sql:/docker-entrypoint-initdb.d/003_conversations.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U remedyiq"]
       interval: 10s

--- a/frontend/src/app/(dashboard)/ai/page.tsx
+++ b/frontend/src/app/(dashboard)/ai/page.tsx
@@ -11,10 +11,13 @@ import { Suspense, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { cn } from '@/lib/utils'
 import { useAnalyses } from '@/hooks/use-api'
+import { useAIProviderSettings } from '@/hooks/use-ai-provider-settings'
 import { useAIStore } from '@/stores/ai-store'
 import { PageState } from '@/components/ui/page-state'
 import { ConversationList } from '@/components/ai/conversation-list'
 import { ChatPanel } from '@/components/ai/chat-panel'
+import { AIProviderSettings } from '@/components/ai/ai-provider-settings'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 
 // ---------------------------------------------------------------------------
 // Inner component (uses useSearchParams inside Suspense)
@@ -29,6 +32,7 @@ function AIPageContent() {
 
   const { activeConversationId } = useAIStore()
   const { data: analysesData, isLoading: analysesLoading } = useAnalyses()
+  const { settings: providerSettings, setSettings: setProviderSettings } = useAIProviderSettings()
   const jobs = analysesData?.jobs ?? []
 
   return (
@@ -94,9 +98,33 @@ function AIPageContent() {
           )}
         </div>
 
+        {/* Model / provider */}
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="ml-auto shrink-0 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-primary)] px-2.5 py-1 text-xs font-medium text-[var(--color-text-secondary)] hover:border-[var(--color-primary)] hover:text-[var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
+              aria-label="AI model and provider settings"
+            >
+              Model:{' '}
+              <span className="text-[var(--color-text-primary)]">
+                {providerSettings.provider === 'gemini'
+                  ? 'Gemini'
+                  : providerSettings.provider === 'openai'
+                    ? 'OpenAI'
+                    : 'Ollama'}
+              </span>
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="end" className="w-[min(100vw-2rem,22rem)] border-[var(--color-border)] bg-[var(--color-bg-primary)] p-3 text-[var(--color-text-primary)] shadow-lg">
+            <p className="mb-2 text-xs font-semibold text-[var(--color-text-primary)]">AI connection</p>
+            <AIProviderSettings settings={providerSettings} onChange={setProviderSettings} />
+          </PopoverContent>
+        </Popover>
+
         {/* Active conversation indicator */}
         {activeConversationId && (
-          <span className="ml-auto flex items-center gap-1.5 text-xs text-[var(--color-text-secondary)]">
+          <span className="flex items-center gap-1.5 text-xs text-[var(--color-text-secondary)]">
             <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-[var(--color-success)]" aria-hidden="true" />
             Active
           </span>
@@ -115,9 +143,16 @@ function AIPageContent() {
           aria-label="Conversations"
           aria-hidden={!sidebarOpen}
         >
-          {sidebarOpen && (
-            <ConversationList jobId={selectedJobId || undefined} />
-          )}
+          {sidebarOpen &&
+            (selectedJobId ? (
+              <ConversationList jobId={selectedJobId} />
+            ) : (
+              <div className="flex flex-1 flex-col justify-center px-3 py-8 text-center">
+                <p className="text-xs leading-relaxed text-[var(--color-text-tertiary)]">
+                  Select an analysis job in the bar above to load conversations or start a new one.
+                </p>
+              </div>
+            ))}
         </aside>
 
         {/* Chat panel */}
@@ -127,6 +162,7 @@ function AIPageContent() {
               jobId={selectedJobId}
               conversationId={activeConversationId}
               className="flex-1"
+              providerSettings={providerSettings}
             />
           ) : (
             <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">

--- a/frontend/src/components/ai/ai-provider-settings.tsx
+++ b/frontend/src/components/ai/ai-provider-settings.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+/**
+ * AI provider configuration: Gemini (Google), OpenAI, or local Ollama (OpenAI-compatible /v1).
+ */
+
+import { useCallback, useId, useState } from 'react'
+import { cn } from '@/lib/utils'
+import type { AIProviderChoice, AIProviderUserSettings } from '@/hooks/use-ai-provider-settings'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface AIProviderSettingsProps {
+  settings: AIProviderUserSettings
+  onChange: (next: AIProviderUserSettings) => void
+  className?: string
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function AIProviderSettings({ settings, onChange, className }: AIProviderSettingsProps) {
+  const baseId = useId()
+  const [showKey, setShowKey] = useState(false)
+
+  const patch = useCallback(
+    (partial: Partial<AIProviderUserSettings>) => {
+      onChange({ ...settings, ...partial })
+    },
+    [onChange, settings],
+  )
+
+  const providerLabel = (p: AIProviderChoice) => {
+    switch (p) {
+      case 'gemini':
+        return 'Google Gemini'
+      case 'openai':
+        return 'OpenAI'
+      case 'ollama':
+        return 'Ollama (local)'
+      default:
+        return p
+    }
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-3 text-xs', className)}>
+      <div className="flex flex-col gap-1">
+        <label htmlFor={`${baseId}-provider`} className="font-semibold text-[var(--color-text-secondary)]">
+          Provider
+        </label>
+        <select
+          id={`${baseId}-provider`}
+          value={settings.provider}
+          onChange={(e) => {
+            const p = e.target.value as AIProviderChoice
+            if (p === 'openai') {
+              onChange({ ...settings, provider: p, openaiBaseUrl: 'https://api.openai.com/v1' })
+              return
+            }
+            if (p === 'ollama') {
+              onChange({ ...settings, provider: p, openaiBaseUrl: 'http://127.0.0.1:11434/v1' })
+              return
+            }
+            onChange({ ...settings, provider: p })
+          }}
+          className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-primary)] px-2 py-1.5 text-[var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
+        >
+          {(['gemini', 'openai', 'ollama'] as const).map((p) => (
+            <option key={p} value={p}>
+              {providerLabel(p)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor={`${baseId}-model`} className="font-semibold text-[var(--color-text-secondary)]">
+          Model{' '}
+          <span className="font-normal text-[var(--color-text-tertiary)]">(optional)</span>
+        </label>
+        <input
+          id={`${baseId}-model`}
+          type="text"
+          value={settings.model}
+          onChange={(e) => patch({ model: e.target.value })}
+          placeholder={
+            settings.provider === 'gemini'
+              ? 'e.g. gemini-2.5-flash'
+              : settings.provider === 'openai'
+                ? 'e.g. gpt-4o-mini'
+                : 'e.g. llama3.2'
+          }
+          className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-primary)] px-2 py-1.5 text-[var(--color-text-primary)] placeholder:text-[var(--color-text-tertiary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
+          autoComplete="off"
+        />
+      </div>
+
+      {(settings.provider === 'ollama' || settings.provider === 'openai') && (
+        <div className="flex flex-col gap-1">
+          <label htmlFor={`${baseId}-base`} className="font-semibold text-[var(--color-text-secondary)]">
+            Base URL
+          </label>
+          <input
+            id={`${baseId}-base`}
+            type="url"
+            value={settings.openaiBaseUrl}
+            onChange={(e) => patch({ openaiBaseUrl: e.target.value })}
+            placeholder={settings.provider === 'ollama' ? 'http://127.0.0.1:11434/v1' : 'https://api.openai.com/v1'}
+            className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-primary)] px-2 py-1.5 font-mono text-[11px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-tertiary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
+            autoComplete="off"
+          />
+          <p className="text-[10px] leading-snug text-[var(--color-text-tertiary)]">
+            Ollama exposes an OpenAI-compatible API at <span className="font-mono">/v1</span>. Use your LAN host if Ollama runs on another machine.
+          </p>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between gap-2">
+          <label htmlFor={`${baseId}-key`} className="font-semibold text-[var(--color-text-secondary)]">
+            API key{' '}
+            <span className="font-normal text-[var(--color-text-tertiary)]">(optional)</span>
+          </label>
+          <button
+            type="button"
+            onClick={() => setShowKey((v) => !v)}
+            className="text-[10px] font-medium text-[var(--color-primary)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
+          >
+            {showKey ? 'Hide' : 'Show'}
+          </button>
+        </div>
+        <input
+          id={`${baseId}-key`}
+          type={showKey ? 'text' : 'password'}
+          value={settings.apiKey}
+          onChange={(e) => patch({ apiKey: e.target.value })}
+          placeholder={
+            settings.provider === 'gemini'
+              ? 'Google AI Studio / Gemini API key'
+              : settings.provider === 'openai'
+                ? 'sk-…'
+                : 'Usually empty for Ollama'
+          }
+          className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-primary)] px-2 py-1.5 font-mono text-[11px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-tertiary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
+          autoComplete="off"
+        />
+        <p className="text-[10px] leading-snug text-[var(--color-text-tertiary)]">
+          Stored only in this browser and sent with chat requests. Server defaults apply when fields are empty.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ai/chat-panel.tsx
+++ b/frontend/src/components/ai/chat-panel.tsx
@@ -27,7 +27,7 @@ function useGetToken() {
   const { getToken } = useAuth()
   return getToken
 }
-import { streamAI } from '@/lib/api'
+import { streamAI, type AIStreamExtras } from '@/lib/api'
 import { queryKeys } from '@/hooks/use-api'
 import { useConversation } from '@/hooks/use-api'
 import { useAIStore } from '@/stores/ai-store'
@@ -36,6 +36,10 @@ import { ChatInput } from './chat-input'
 import { SkillSelector } from './skill-selector'
 import { FollowUpSuggestions } from './follow-up-suggestions'
 import { PageState } from '@/components/ui/page-state'
+import {
+  defaultAIProviderUserSettings,
+  type AIProviderUserSettings,
+} from '@/hooks/use-ai-provider-settings'
 import type { Message } from '@/lib/api-types'
 
 // ---------------------------------------------------------------------------
@@ -46,6 +50,8 @@ interface ChatPanelProps {
   jobId: string
   conversationId: string | null
   className?: string
+  /** LLM provider / BYOK — defaults to Gemini using server configuration. */
+  providerSettings?: AIProviderUserSettings
 }
 
 // ---------------------------------------------------------------------------
@@ -91,7 +97,12 @@ function EmptyChat({ onSuggest }: { onSuggest: (msg: string) => void }) {
 // ChatPanel
 // ---------------------------------------------------------------------------
 
-export function ChatPanel({ jobId, conversationId, className }: ChatPanelProps) {
+export function ChatPanel({
+  jobId,
+  conversationId,
+  className,
+  providerSettings = defaultAIProviderUserSettings,
+}: ChatPanelProps) {
   const getToken = useGetToken()
   const queryClient = useQueryClient()
   const messagesEndRef = useRef<HTMLDivElement>(null)
@@ -135,7 +146,18 @@ export function ChatPanel({ jobId, conversationId, className }: ChatPanelProps) 
 
       try {
         const token = await getToken()
-        const gen = streamAI(jobId, conversationId, text, selectedSkill ?? undefined, token ?? undefined)
+        const ps = providerSettings
+        const extras: AIStreamExtras = {
+          provider: ps.provider,
+          auto_route: selectedSkill === null,
+          ...(selectedSkill ? { skill_name: selectedSkill } : {}),
+          ...(ps.model.trim() ? { model: ps.model.trim() } : {}),
+          ...(ps.apiKey.trim() ? { api_key: ps.apiKey.trim() } : {}),
+          ...((ps.provider === 'openai' || ps.provider === 'ollama') && ps.openaiBaseUrl.trim()
+            ? { openai_base_url: ps.openaiBaseUrl.trim() }
+            : {}),
+        }
+        const gen = streamAI(jobId, conversationId, text, extras, token ?? undefined)
 
         // Set up abort capability
         let aborted = false
@@ -180,6 +202,7 @@ export function ChatPanel({ jobId, conversationId, className }: ChatPanelProps) 
       appendToken,
       stopStreaming,
       queryClient,
+      providerSettings,
     ],
   )
 
@@ -188,6 +211,18 @@ export function ChatPanel({ jobId, conversationId, className }: ChatPanelProps) 
     stopStreaming()
     setPendingMessage(null)
   }, [stopStreaming])
+
+  useEffect(() => {
+    if (!isStreaming) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        handleStop()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [isStreaming, handleStop])
 
   // No conversation selected
   if (!conversationId) {

--- a/frontend/src/components/ai/conversation-list.test.tsx
+++ b/frontend/src/components/ai/conversation-list.test.tsx
@@ -199,7 +199,7 @@ describe('ConversationList', () => {
   // -------------------------------------------------------------------------
 
   it('shows empty state when no conversations exist', () => {
-    render(<ConversationList />)
+    render(<ConversationList jobId="job-1" />)
     expect(screen.getByText(/no conversations yet/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /start one/i })).toBeInTheDocument()
   })
@@ -212,10 +212,20 @@ describe('ConversationList', () => {
     } as unknown as ReturnType<typeof useCreateConversation>)
 
     const user = userEvent.setup()
-    render(<ConversationList />)
+    render(<ConversationList jobId="job-1" />)
     await user.click(screen.getByRole('button', { name: /start one/i }))
 
-    expect(mutate).toHaveBeenCalled()
+    expect(mutate).toHaveBeenCalledWith(
+      { jobId: 'job-1', title: 'New conversation' },
+      expect.any(Object),
+    )
+  })
+
+  it('disables new conversation actions when no job is selected', () => {
+    mockUseCreateConversation.mockReturnValue(makeCreateMutation() as unknown as ReturnType<typeof useCreateConversation>)
+    render(<ConversationList />)
+    expect(screen.getByRole('button', { name: /new conversation/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /start one/i })).toBeDisabled()
   })
 
   // -------------------------------------------------------------------------
@@ -411,7 +421,7 @@ describe('ConversationList', () => {
       isPending: true,
     } as unknown as ReturnType<typeof useCreateConversation>)
 
-    render(<ConversationList />)
+    render(<ConversationList jobId="job-1" />)
     expect(screen.getByRole('button', { name: /new conversation/i })).toBeDisabled()
   })
 })

--- a/frontend/src/components/ai/conversation-list.tsx
+++ b/frontend/src/components/ai/conversation-list.tsx
@@ -168,22 +168,25 @@ function ConversationItem({
 
 export function ConversationList({ jobId, className }: ConversationListProps) {
   const { activeConversationId, setConversation } = useAIStore()
-  const { data, isLoading, isError, refetch } = useConversations(jobId ?? undefined)
+  const jobIdTrimmed = jobId?.trim() ?? ''
+  const hasJob = jobIdTrimmed.length > 0
+  const { data, isLoading, isError, refetch } = useConversations(hasJob ? jobIdTrimmed : undefined)
   const createMutation = useCreateConversation()
   const deleteMutation = useDeleteConversation()
 
   const conversations = data?.conversations ?? []
 
   const handleNew = useCallback(() => {
+    if (!hasJob) return
     createMutation.mutate(
-      { jobId: jobId ?? undefined, title: 'New conversation' },
+      { jobId: jobIdTrimmed, title: 'New conversation' },
       {
         onSuccess: (conv) => {
           setConversation(conv.id)
         },
       },
     )
-  }, [createMutation, jobId, setConversation])
+  }, [createMutation, hasJob, jobIdTrimmed, setConversation])
 
   const handleDelete = useCallback(
     (id: string) => {
@@ -212,9 +215,9 @@ export function ConversationList({ jobId, className }: ConversationListProps) {
         <button
           type="button"
           onClick={handleNew}
-          disabled={createMutation.isPending}
+          disabled={!hasJob || createMutation.isPending}
           aria-label="New conversation"
-          title="New conversation"
+          title={hasJob ? 'New conversation' : 'Select an analysis job first'}
           className="rounded p-1 text-[var(--color-primary)] transition-colors hover:bg-[var(--color-primary-light)] disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
         >
           {createMutation.isPending ? (
@@ -249,7 +252,9 @@ export function ConversationList({ jobId, className }: ConversationListProps) {
             <button
               type="button"
               onClick={handleNew}
-              className="text-xs font-medium text-[var(--color-primary)] hover:underline focus-visible:outline-none"
+              disabled={!hasJob || createMutation.isPending}
+              title={hasJob ? undefined : 'Select an analysis job first'}
+              className="text-xs font-medium text-[var(--color-primary)] hover:underline focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 disabled:no-underline"
             >
               Start one
             </button>

--- a/frontend/src/hooks/use-ai-provider-settings.ts
+++ b/frontend/src/hooks/use-ai-provider-settings.ts
@@ -1,0 +1,72 @@
+'use client'
+
+/**
+ * Persists AI provider / model / BYOK fields in localStorage for the AI Assistant page.
+ * Keys are only stored in the browser; the backend uses them per request when provided.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'remedyiq-ai-provider-v1'
+
+export type AIProviderChoice = 'gemini' | 'openai' | 'ollama'
+
+export interface AIProviderUserSettings {
+  provider: AIProviderChoice
+  /** Model id override (e.g. gpt-4o-mini, llama3.2, gemini-2.5-flash). */
+  model: string
+  /** OpenAI-compatible API base URL (Ollama default includes /v1). */
+  openaiBaseUrl: string
+  /** Optional API key (OpenAI, Google AI Studio, or unused for local Ollama). */
+  apiKey: string
+}
+
+export const defaultAIProviderUserSettings: AIProviderUserSettings = {
+  provider: 'gemini',
+  model: '',
+  openaiBaseUrl: 'http://127.0.0.1:11434/v1',
+  apiKey: '',
+}
+
+function normalizeProvider(v: unknown): AIProviderChoice {
+  const s = String(v ?? '').toLowerCase()
+  if (s === 'openai' || s === 'ollama' || s === 'gemini') return s
+  return 'gemini'
+}
+
+function load(): AIProviderUserSettings {
+  if (typeof window === 'undefined') return defaultAIProviderUserSettings
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return defaultAIProviderUserSettings
+    const v = JSON.parse(raw) as Partial<AIProviderUserSettings>
+    return {
+      provider: normalizeProvider(v.provider),
+      model: typeof v.model === 'string' ? v.model : '',
+      openaiBaseUrl:
+        typeof v.openaiBaseUrl === 'string' ? v.openaiBaseUrl : defaultAIProviderUserSettings.openaiBaseUrl,
+      apiKey: typeof v.apiKey === 'string' ? v.apiKey : '',
+    }
+  } catch {
+    return defaultAIProviderUserSettings
+  }
+}
+
+export function useAIProviderSettings() {
+  const [settings, setSettingsState] = useState<AIProviderUserSettings>(defaultAIProviderUserSettings)
+
+  useEffect(() => {
+    setSettingsState(load())
+  }, [])
+
+  const setSettings = useCallback((next: AIProviderUserSettings) => {
+    setSettingsState(next)
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+    } catch {
+      // ignore quota / private mode
+    }
+  }, [])
+
+  return { settings, setSettings }
+}

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -794,6 +794,13 @@ export interface AIStreamRequest {
   conversation_id: string;
   query: string;
   skill?: string;
+  skill_name?: string;
+  auto_route?: boolean;
+  /** gemini | openai | ollama */
+  provider?: string;
+  model?: string;
+  api_key?: string;
+  openai_base_url?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -910,17 +910,26 @@ export async function getSearchHistory(
  *
  * @example
  * ```ts
- * const gen = streamAI(jobId, conversationId, "Why are these queries slow?");
+ * const gen = streamAI(jobId, conversationId, "Why are these queries slow?", { auto_route: true });
  * for await (const event of gen) {
  *   if (event.type === "token") appendText(event.content ?? "");
  * }
  * ```
  */
+export type AIStreamExtras = {
+  skill_name?: string;
+  auto_route?: boolean;
+  provider?: string;
+  model?: string;
+  api_key?: string;
+  openai_base_url?: string;
+};
+
 export async function* streamAI(
   jobId: string,
   conversationId: string,
   message: string,
-  skill?: string,
+  extras: AIStreamExtras | undefined,
   token?: string,
 ): AsyncGenerator<import("./api-types").AIStreamEvent, void, unknown> {
   const url = `${API_BASE}/ai/stream`;
@@ -929,8 +938,25 @@ export async function* streamAI(
     job_id: jobId,
     conversation_id: conversationId,
     query: message,
-    skill,
   };
+  if (extras?.skill_name) {
+    body.skill_name = extras.skill_name;
+  }
+  if (extras?.auto_route !== undefined) {
+    body.auto_route = extras.auto_route;
+  }
+  if (extras?.provider) {
+    body.provider = extras.provider;
+  }
+  if (extras?.model) {
+    body.model = extras.model;
+  }
+  if (extras?.api_key) {
+    body.api_key = extras.api_key;
+  }
+  if (extras?.openai_base_url) {
+    body.openai_base_url = extras.openai_base_url;
+  }
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -1062,7 +1088,11 @@ export async function createConversation(
   title?: string,
   token?: string,
 ): Promise<Conversation> {
-  const body: CreateConversationRequest = { job_id: jobId, title };
+  const jid = jobId?.trim() ?? ''
+  if (!jid) {
+    throw new ApiError(400, 'INVALID_REQUEST', 'job_id is required to create a conversation')
+  }
+  const body: CreateConversationRequest = { job_id: jid, title };
   return apiFetch<Conversation>(
     "/ai/conversations",
     { method: "POST", body: JSON.stringify(body) },


### PR DESCRIPTION
This PR merges work from the Cursor worktree (a40w).

## Summary
- **AI streaming**: Gemini with optional BYOK/model override; OpenAI-compatible and **Ollama** streaming on the Go SSE path; server defaults from env (`OPENAI_*`, `OLLAMA_BASE_URL`).
- **API**: Extended stream request (provider, model, api_key, openai_base_url); fixed skill routing (`skill_name` + `auto_route`); `skill` JSON alias.
- **Frontend**: AI provider settings (popover + localStorage), stream extras, Escape to stop streaming; require a job before creating/listing conversations in the UI; `createConversation` client guard.
- **Docker/DB**: Postgres init mounts migrations **002** and **003**; `make migrate-up` applies 001–003; idempotent trigger drop in **003**.

## Verification
- `go build ./cmd/api/...`, `go test ./internal/ai/...`, AI stream handler tests.
- Frontend `vitest` for conversation list.

**Note:** After deploy or fresh Docker volumes, run `make migrate-up` once if an existing volume predates the new init scripts.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added support for multiple AI providers: Gemini, OpenAI, and Ollama.
- New AI provider settings panel to configure your preferred AI backend, model, and API credentials.
- Support for custom OpenAI-compatible endpoints and API keys.
- Enhanced database schema for improved conversations and search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->