### PR TITLE
fix(#19): upgrade @clerk/nextjs to ^6.39.2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.2.0",
       "dependencies": {
-        "@clerk/nextjs": "^6.37.3",
+        "@clerk/nextjs": "^6.39.2",
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.62.0",
         "class-variance-authority": "^0.7.1",
@@ -675,13 +675,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@clerk/backend": {
-      "version": "2.33.1",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.1.tgz",
-      "integrity": "sha512-DRwmFu6gEmzHRUeXXB5y02QxMihHDEgetSQrb0ME6KaYe29+LnenBUQAmlASXmsovIi9cBqk4hE4WHWNRXX+Bw==",
+      "version": "2.33.2",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.2.tgz",
+      "integrity": "sha512-5nNPTdSLCTt7yVvMdd5CoEYZXVQhA9i0C50PxmAOjApYDIEfASedP9KXRb+YARiDrOSHQg0qFJhWUnujaG3hpw==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.3",
-        "@clerk/types": "^4.101.21",
+        "@clerk/shared": "^3.47.4",
+        "@clerk/types": "^4.101.22",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -690,12 +690,12 @@
       }
     },
     "node_modules/@clerk/clerk-react": {
-      "version": "5.61.4",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.4.tgz",
-      "integrity": "sha512-xGvQvzfc5pQEuqCW8CNUgnlR+9nt6gSSMGMYx3l972utIJrFKByQJFCRZpwYBvAHiveuK11Wgy3J39p904jb+w==",
+      "version": "5.61.5",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.5.tgz",
+      "integrity": "sha512-MKVEsvRR47WlizFki5BPjLIm1TPbJju4m2CNJGzrRqhEMide0Yjm4DGYfh/r2k/uFjOGMWfSJ7EToM1y2AQ5rg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.3",
+        "@clerk/shared": "^3.47.4",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -707,15 +707,15 @@
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "6.39.1",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.1.tgz",
-      "integrity": "sha512-crc6nJOK+1V7kf7tMxeoOaJK9/HHGbjqWm1rW11RrRKA7lnaIeCUtO6kSy8dZ/4ZyVfUACVOwUdQM7EqwHmzWg==",
+      "version": "6.39.2",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.2.tgz",
+      "integrity": "sha512-NTAgvhpntCdQD4KR+4f/KFs8cqd6oyzoE73AoO9w0xKoJbTB8IIIPG+CtdIw+mx7z4JqbQATKWZbMPGeZbZYCw==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^2.33.1",
-        "@clerk/clerk-react": "^5.61.4",
-        "@clerk/shared": "^3.47.3",
-        "@clerk/types": "^4.101.21",
+        "@clerk/backend": "^2.33.2",
+        "@clerk/clerk-react": "^5.61.5",
+        "@clerk/shared": "^3.47.4",
+        "@clerk/types": "^4.101.22",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
@@ -729,9 +729,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.47.3",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.3.tgz",
-      "integrity": "sha512-jG0wMIZuuc8zaKieg9Os8ocTphG+llluRukUUdyVnu4+ZI1syVf+dkpDP3ZK69yLavTX3D0KAmkmQqTPzQV/Nw==",
+      "version": "3.47.4",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.4.tgz",
+      "integrity": "sha512-0O5/zgB5SO26PKarAIw7uj4j+4JsnT2/uiJ7SPI3LQMb62sM+AjDlVadcXuYc+4sY6w1szrAIVepI5Bkv57hnQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -759,12 +759,12 @@
       }
     },
     "node_modules/@clerk/types": {
-      "version": "4.101.21",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.21.tgz",
-      "integrity": "sha512-/70W603A6bRv1n24dDNAs3kWHLSIgXebEyzXZ46IuROWcq0+guSqqLa+nKekxxIdk6I/vnI9SWjBvBRuZVMnhQ==",
+      "version": "4.101.22",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.22.tgz",
+      "integrity": "sha512-74hV9MMw9MzOOSuJNJMFP95XZ2jDfPS1v3pfALS3rSQa+h/lNREU+fLGArzYckEpqNtuF6xy0odg9YqF5BLNhA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.3"
+        "@clerk/shared": "^3.47.4"
       },
       "engines": {
         "node": ">=18.17.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
-    "@clerk/nextjs": "^6.37.3",
+    "@clerk/nextjs": "^6.39.2",
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.62.0",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary

- Upgrades \`@clerk/nextjs\` from \`^6.37.3\` to \`^6.39.2\`
- Fixes GHSA-vqx2-fgx2-5wq9 — critical middleware-based route protection bypass affecting all versions 6.0.0–6.39.1
- Stays within v6 to avoid breaking API changes introduced in v7 (\`SignedIn\`/\`SignedOut\` components removed)
- Zero critical vulnerabilities remain after upgrade (\`npm audit --audit-level=critical\` clean)

## Test plan

- [ ] \`npm run build\` passes
- [ ] \`npm run lint\` passes
- [ ] \`npm audit --audit-level=critical\` returns 0 criticals
- [ ] \`npm Audit (frontend)\` CI job passes

Closes #19

---

## Glossary

| Term | Definition |
|------|------------|
| GHSA-vqx2-fgx2-5wq9 | GitHub Security Advisory for Clerk middleware route protection bypass — an attacker could bypass auth middleware in affected versions |
| @clerk/nextjs | Official Clerk authentication SDK for Next.js |
| npm audit | Node.js dependency vulnerability scanner |